### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,13 @@ set(EXTENSION_HOMEPAGE "https://www.slicer.org/wiki/Documentation/Nightly/Extens
 set(EXTENSION_CATEGORY "Diffusion")
 set(EXTENSION_CONTRIBUTORS "Antonio Senra Filho (State University of Campinas), André M. Paschoal (State University of Campinas)")
 set(EXTENSION_DESCRIPTION "Module that calculates the diffusion tensor image analysis along the perivascular space (DTI-ALPS) index")
-set(EXTENSION_ICONURL "https://www.slicer.org/w/img_auth.php/6/68/DTIALPS-logo.png")
-set(EXTENSION_SCREENSHOTURLS "https://www.slicer.org/w/img_auth.php/f/f5/DTI-ALPS-sc-1.png https://www.slicer.org/w/img_auth.php/9/92/DTI-ALPS-sc-2.png https://www.slicer.org/w/img_auth.php/0/0b/DTI-ALPS-sc-3-proj-label.png https://www.slicer.org/w/img_auth.php/2/2f/DTI-ALPS-sc-4-assoc-label.png")
+set(EXTENSION_ICONURL "https://raw.githubusercontent.com/LOAMRI/Slicer-DTI-ALPS/main/DTI_ALPS.png")
+set(EXTENSION_SCREENSHOTURLS
+  "https://www.slicer.org/w/img_auth.php/f/f5/DTI-ALPS-sc-1.png"
+  "https://www.slicer.org/w/img_auth.php/9/92/DTI-ALPS-sc-2.png"
+  "https://www.slicer.org/w/img_auth.php/0/0b/DTI-ALPS-sc-3-proj-label.png"
+  "https://www.slicer.org/w/img_auth.php/2/2f/DTI-ALPS-sc-4-assoc-label.png"
+)
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Set `EXTENSION_ICONURL` using the GitHub raw URL instead of the file hosted on the Slicer wiki.

Set `EXTENSION_SCREENSHOTURLS` as a list leveraging support introduced in Slicer/Slicer@1b9bd54b06 (`ENH: Support specifying screenshot URL extension metadata as string or list`, 2024-04-16)

Related pull requests:
* https://github.com/Slicer/ExtensionsIndex/pull/2013