### PR TITLE
BUG: Fix Slicer extensions index failed to build due to mismatch name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.3...3.27 FATAL_ERROR)
 
-project(Slicer-DTI-ALPS)
+project(DTI-ALPS)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information


### PR DESCRIPTION
To address a [build error](https://slicer.cdash.org/viewBuildError.php?buildid=3708651) where `SlicerDTIALPS.json` did not match `project(Slicer-DTI-ALPS)`. 

This change will be compatible with https://github.com/Slicer/ExtensionsIndex/pull/2147.